### PR TITLE
Adding missing parameter to SSH iptable rules

### DIFF
--- a/tasks/iptables.yml
+++ b/tasks/iptables.yml
@@ -69,6 +69,7 @@
   ansible.builtin.iptables:
     chain: INPUT
     protocol: tcp
+    destination_port: "{{ ssh_port }}"
     match: state
     ctstate: NEW
     jump: ACCEPT


### PR DESCRIPTION
The original configuration was not complete, as a consecuence was accepting all the incoming traffic in all ports. With this change it is restricted only to the ssh port.

After this change:
```
Chain INPUT (policy DROP 19 packets, 13536 bytes)
 pkts bytes target     prot opt in     out     source               destination         
    0     0 DROP       all  --  any    any     anywhere             anywhere             state INVALID /* drop invalid */
    0     0 DROP       tcp  --  any    any     anywhere             anywhere             state NEW tcp flags:!FIN,SYN,RST,ACK/SYN /* drop new TCP packets without the SYN flag */
    0     0 LOG        tcp  --  any    any     anywhere             anywhere             tcp flags:FIN,SYN,RST,PSH,ACK,URG/FIN,PSH,URG /* drop XMAS packets */ LOG level warning prefix "DROPPED XMAS PACKET:"
 1205 1740K ACCEPT     all  --  any    any     anywhere             anywhere             ctstate RELATED,ESTABLISHED /* allow related and established connections */
  502  799K ACCEPT     tcp  --  any    any     anywhere             anywhere             tcp dpt:666
    1   438 ACCEPT     all  --  lo     any     anywhere             anywhere             /* allow internal traffic */
    0     0 ACCEPT     tcp  --  any    any     anywhere             anywhere             state NEW tcp dpt:666 /* allow SSH port */
    0     0 ACCEPT     icmp --  any    any     anywhere             anywhere             icmp echo-request /* allow ICMP ping */

Chain FORWARD (policy DROP 15 packets, 886 bytes)
 pkts bytes target     prot opt in     out     source               destination         

Chain OUTPUT (policy ACCEPT 709 packets, 66834 bytes)
 pkts bytes target     prot opt in     out     source               destination         

```

Prior to this change:

```
Chain INPUT (policy DROP)
target     prot opt source               destination         
DROP       all  --  anywhere             anywhere             state INVALID /* drop invalid */
DROP       tcp  --  anywhere             anywhere             state NEW tcp flags:!FIN,SYN,RST,ACK/SYN /* drop new TCP packets without the SYN flag */
LOG        tcp  --  anywhere             anywhere             tcp flags:FIN,SYN,RST,PSH,ACK,URG/FIN,PSH,URG /* drop XMAS packets */ LOG level warning prefix "DROPPED XMAS PACKET:"
ACCEPT     all  --  anywhere             anywhere             ctstate RELATED,ESTABLISHED /* allow related and established connections */
ACCEPT     tcp  --  anywhere             anywhere             tcp dpt:666
ACCEPT     all  --  anywhere             anywhere             /* allow internal traffic */
ACCEPT     tcp  --  anywhere             anywhere             state NEW /* allow SSH port */
ACCEPT     icmp --  anywhere             anywhere             icmp echo-request /* allow ICMP ping */

Chain FORWARD (policy DROP)
target     prot opt source               destination         

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         
```

Please review this change, I am not totally sure about its impact. Have a nice day :)